### PR TITLE
Bump some dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,16 @@
 source 'http://rubygems.org'
 
 gem 'awesome_print', '~> 1.6'
-gem 'json', '~> 1.8'
-gem 'nokogiri', '~> 1.6'
+gem 'json', '~> 2.0'
+gem 'nokogiri', '~> 1.8'
 
 group :development do
-  gem 'coveralls', '~> 0.8'
+  gem 'coveralls', '~> 0.8.21'
   gem 'flay', '~> 2.6'
   gem 'flog', '~> 4.3'
   gem 'guard-rspec', '~> 4.6'
   gem 'jeweler', '~> 2.0'
   gem 'rspec', '~> 3.0'
-  gem 'rubocop', '~> 0.31'
-  gem 'simplecov', '~> 0.10'
+  gem 'rubocop', '~> 0.51'
+  gem 'simplecov', '~> 0.14.1'
 end


### PR DESCRIPTION
👋 @pixelastic 

the intent of this PR is to bump `json` to 2.0 to be able to use `algoliasearch-jekyll` with other jekyll plugins relying on `json`.

As `test-ci` passed, I also bumped some other gems to their latest versions.